### PR TITLE
clear the cache every 12 hours

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
 import streamlit as st
 from mitosheet.streamlit.v1 import spreadsheet
-import pandas as pd
+from mitosheet.streamlit.v1.spreadsheet import _get_mito_backend
 
 st.set_page_config(layout="wide")
 
@@ -14,4 +17,30 @@ def get_tesla_data():
 tesla_data = get_tesla_data()
 
 new_dfs, code = spreadsheet(tesla_data)
+code = code if code else "# Edit the spreadsheet above to generate code"
 st.code(code)
+
+def clear_mito_backend_cache():
+    _get_mito_backend.clear()
+
+# Function to cache the last execution time - so we can clear
+# periodically
+@st.cache_resource
+def get_cached_time():
+    # Initialize with a dictionary to store the last execution hour
+    return {"last_executed_time": None}
+
+def try_clear_cache():
+
+    # How often to clear the cache
+    CLEAR_DELTA = timedelta(hours=12)
+
+    current_time = datetime.now()
+    cached_time = get_cached_time()
+
+    # Check if the current hour is different from the cached last execution hour
+    if cached_time["last_executed_time"] is None or cached_time["last_executed_time"] + CLEAR_DELTA < current_time:
+        clear_mito_backend_cache()
+        cached_time["last_executed_time"] = current_time
+
+try_clear_cache()

--- a/main.py
+++ b/main.py
@@ -23,11 +23,10 @@ st.code(code)
 def clear_mito_backend_cache():
     _get_mito_backend.clear()
 
-# Function to cache the last execution time - so we can clear
-# periodically
+# Function to cache the last execution time - so we can clear periodically
 @st.cache_resource
 def get_cached_time():
-    # Initialize with a dictionary to store the last execution hour
+    # Initialize with a dictionary to store the last execution time
     return {"last_executed_time": None}
 
 def try_clear_cache():
@@ -38,7 +37,7 @@ def try_clear_cache():
     current_time = datetime.now()
     cached_time = get_cached_time()
 
-    # Check if the current hour is different from the cached last execution hour
+    # Check if the current time is different from the cached last execution time
     if cached_time["last_executed_time"] is None or cached_time["last_executed_time"] + CLEAR_DELTA < current_time:
         clear_mito_backend_cache()
         cached_time["last_executed_time"] = current_time


### PR DESCRIPTION
This will make the app go down way less often.

- note there is a flicker the first time the app is used ever (just by the first user - not by any other user - so this is not an issue)
- Note that there will be a flicker for anyone using the app across the 12 hour boundary. this is also fine as it's a basic demo app.

You can test easily by changing the time delta to 1 minute, and seeing that flicker on first ever usage, and then across the minute boundary, but everything works correctly otherwise. 